### PR TITLE
Add a sketch of the desired interface to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # archived_interaction
+
 Ruby library to archive http interactions into a git repository for future retrieval
+
+## Usage
+
+### Storing an interaction
+
+```ruby
+require 'archived_interaction'
+require 'open-uri'
+
+response = open('http://example.com')
+ArchivedInteraction.new(url: response.base_url, body: response.read).store
+```
+
+### Retrieving an interaction
+
+```ruby
+require 'archived_interaction'
+
+interaction = ArchivedInteraction.new(url: 'http://example.com').retrieve
+interaction.url # => "http://example.com"
+```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Ruby library to archive http interactions into a git repository for future retri
 
 ### Storing an interaction
 
+The minimum required to store an interaction is a `url` and a `body`.
+
 ```ruby
 require 'archived_interaction'
 require 'open-uri'
@@ -14,11 +16,63 @@ response = open('http://example.com')
 ArchivedInteraction.new(url: response.base_url, body: response.read).store
 ```
 
+### Storing an interaction with a custom timestamp
+
+If you've got an http interaction that happened at some point in the past then
+you can store that with a custom timestamp.
+
+```ruby
+require 'archived_interaction'
+require 'open-uri'
+
+response = open('http://example.com')
+ArchivedInteraction.new(
+  url: response.base_url,
+  body: response.read,
+  timestamp: Time.parse('2016-10-26 15:30')
+).store
+```
+
+### Adding custom metadata to stored interactions
+
+You can add arbitrary metadata to interactions by including it in a `metadata` key.
+
+```ruby
+require 'archived_interaction'
+require 'open-uri'
+
+response = open('http://example.com')
+ArchivedInteraction.new(
+  url: response.base_url,
+  body: response.read,
+  metadata: {
+    response: {
+      headers: {
+        'X-Useful-Header' => 'example useful information',
+      }
+    }
+  }
+).store
+```
+
 ### Retrieving an interaction
+
+If you just want to retrieve the latest interaction for a known url then you can retrieve it like this:
 
 ```ruby
 require 'archived_interaction'
 
 interaction = ArchivedInteraction.new(url: 'http://example.com').retrieve
+interaction.url # => "http://example.com"
+```
+
+### Retrieving an interaction at a known date
+
+You might want to get a historical interaction which was recorded in the past, to do this pass a timestamp in as well.
+
+```ruby
+require 'archived_interaction'
+
+interaction = ArchivedInteraction.new(url: 'http://example.com', timestamp: Time.parse('2015-05-05 15:00')).retrieve
 interaction.url # => "http://example.com"
 ```


### PR DESCRIPTION
This gem is intended to be a replacement for the core of [`scraped_page_archive`](https://github.com/everypolitician/scraped_page_archive). It's main goal is to allow a simple interface for storing and retrieving http interactions (i.e. requests/responses) in a git repository.
